### PR TITLE
Fix typo Lokalise::Error::MethodNowAllowed

### DIFF
--- a/docs/additional_info/exception_handling.md
+++ b/docs/additional_info/exception_handling.md
@@ -10,7 +10,7 @@ The gem may raise the following custom exceptions:
 * `Lokalise::Error::Unauthorized` (`401`) - token is missing or incorrect
 * `Lokalise::Error::Forbidden` (`403`) - authenticated user does not have sufficient rights to perform the desired action
 * `Lokalise::Error::NotFound` (`404`) - the provided endpoint (resource) cannot be found
-* `Lokalise::Error::MethodNowAllowed` (`405`) - HTTP request with the provided verb is not supported by the endpoint
+* `Lokalise::Error::MethodNotAllowed` (`405`) - HTTP request with the provided verb is not supported by the endpoint
 * `Lokalise::Error::NotAcceptable` (`406`) - posted resource is malformed
 * `Lokalise::Error::Conflict` (`409`) - request conflicts with another request
 * `Lokalise::Error::Locked` (`423`) - your token is used simultaneously in multiple requests

--- a/lib/ruby-lokalise-api/error.rb
+++ b/lib/ruby-lokalise-api/error.rb
@@ -13,7 +13,7 @@ module Lokalise
     TooManyRequests = Class.new(ClientError)
     Forbidden = Class.new(ClientError)
     Locked = Class.new(ClientError)
-    MethodNowAllowed = Class.new(ClientError)
+    MethodNotAllowed = Class.new(ClientError)
 
     NotImplemented = Class.new(ServerError)
     BadGateway = Class.new(ServerError)
@@ -25,7 +25,7 @@ module Lokalise
       401 => Lokalise::Error::Unauthorized,
       403 => Lokalise::Error::Forbidden,
       404 => Lokalise::Error::NotFound,
-      405 => Lokalise::Error::MethodNowAllowed,
+      405 => Lokalise::Error::MethodNotAllowed,
       406 => Lokalise::Error::NotAcceptable,
       409 => Lokalise::Error::Conflict,
       423 => Lokalise::Error::Locked,


### PR DESCRIPTION
### Summary

This PR changes the naming of Lokalise::Error::MethodNowAllowed to be Lokalise::Error::MethodNotAllowed, I believe this is unwanted for the status [405](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405).
Existing usage of `Lokalise::Error::MethodNowAllowed` can be NameError so a minor version update will satisfy semver's compliance, but I'll leave the gem authors to decide. 

### Other Information

N/A